### PR TITLE
Update plugin for netbox 4.2

### DIFF
--- a/netbox_napalm_plugin/__init__.py
+++ b/netbox_napalm_plugin/__init__.py
@@ -22,7 +22,7 @@ class NapalmPlatformConfig(PluginConfig):
         'NAPALM_ARGS': {},
     }
     min_version = '4.0.2'
-    max_version = '4.1.99'
+    max_version = '4.2.99'
 
 
 config = NapalmPlatformConfig

--- a/netbox_napalm_plugin/api/serializers.py
+++ b/netbox_napalm_plugin/api/serializers.py
@@ -1,4 +1,4 @@
-from dcim.api.nested_serializers import NestedPlatformSerializer
+from dcim.api.serializers_.platforms import PlatformSerializer
 from netbox.api.serializers import NetBoxModelSerializer
 from rest_framework import serializers
 
@@ -9,7 +9,7 @@ class NapalmPlatformConfigSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="plugins-api:netbox_napalm_plugin-api:napalmplatformconfig-detail"
     )
-    platform = NestedPlatformSerializer()
+    platform = PlatformSerializer(nested=True)
 
     class Meta:
         model = NapalmPlatformConfig


### PR DESCRIPTION
I have prepared the plugin for compatibility with the upcoming 4.2 version.
I tested it on my 4.2-beta1 installation.
The version would still have to be updated for a new release.

Best Regards