### PR TITLE
Fixes: #52 - Version Bump for NetBox 4.3

### DIFF
--- a/netbox_napalm_plugin/__init__.py
+++ b/netbox_napalm_plugin/__init__.py
@@ -22,7 +22,7 @@ class NapalmPlatformConfig(PluginConfig):
         'NAPALM_ARGS': {},
     }
     min_version = '4.0.2'
-    max_version = '4.2.99'
+    max_version = '4.3.99'
 
 
 config = NapalmPlatformConfig


### PR DESCRIPTION
Fixes: #52 - Version Bump for NetBox 4.3

* Update `__init__.py` variable `max_version` to `4.3.99`